### PR TITLE
change to RFC3339 (1.4.0)

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -20,8 +20,9 @@ import (
 
 // 常量定义
 const (
-	timeFormat     = "02/Jan/2006:15:04:05 -0700" // 日志时间格式
-	defaultBufSize = 1000                         // 日志通道的默认缓冲区大小
+	//timeFormat     = "02/Jan/2006:15:04:05 -0700" // 日志时间格式
+	timeFormat     = time.RFC3339 // 日志时间格式
+	defaultBufSize = 1000         // 日志通道的默认缓冲区大小
 )
 
 // 日志等级常量


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Standardized log timestamps to the RFC 3339 format for clearer and consistent time records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->